### PR TITLE
makefile: fix parallel build failures due to missing objdirs

### DIFF
--- a/makefile
+++ b/makefile
@@ -91,6 +91,9 @@ Source/BlahtexCore/InputSymbolTranslation.inc: Source/BlahtexCore/InputSymbolTra
 
 Source/BlahtexCore/InputSymbolTranslation.cpp: Source/BlahtexCore/InputSymbolTranslation.inc
 
+$(OBJECTS): $(BINDIR)
+$(OBJECTS_XMLIN): $(BINDIR_XMLIN)
+
 $(BINDIR)/InputSymbolTranslation.o: InputSymbolTranslation.cpp InputSymbolTranslation.inc
 
 $(BINDIR_XMLIN)/InputSymbolTranslation.o: InputSymbolTranslation.cpp InputSymbolTranslation.inc

--- a/makefile.mingw
+++ b/makefile.mingw
@@ -93,6 +93,9 @@ Source/BlahtexCore/InputSymbolTranslation.inc: Source/BlahtexCore/InputSymbolTra
 
 Source/BlahtexCore/InputSymbolTranslation.cpp: Source/BlahtexCore/InputSymbolTranslation.inc
 
+$(OBJECTS): $(BINDIR)
+$(OBJECTS_XMLIN): $(BINDIR_XMLIN)
+
 $(BINDIR)/InputSymbolTranslation.o: InputSymbolTranslation.cpp InputSymbolTranslation.inc
 
 $(BINDIR_XMLIN)/InputSymbolTranslation.o: InputSymbolTranslation.cpp InputSymbolTranslation.inc


### PR DESCRIPTION
The error is best reproducible with GNU make 4.4's `make --shuffle` build:

    $ make --shuffle
    ...
    Fatal error: can't create bin-blahtex/Messages.o: No such file or directory

The build fails because `$(BINDIR)` is not ready yet. Add `$(BINDIR)` to dependencies of all object files.